### PR TITLE
Add support for Ruby 3.3

### DIFF
--- a/lib/rgfa/byte_array.rb
+++ b/lib/rgfa/byte_array.rb
@@ -18,7 +18,6 @@ class RGFA::ByteArray < Array
           "in array: #{self.inspect}"
       end
     end
-    self.trust
     return nil
   end
 

--- a/lib/rgfa/field_validator.rb
+++ b/lib/rgfa/field_validator.rb
@@ -242,6 +242,23 @@ class Fixnum
   end
 end
 
+class Integer
+  # @!macro validate_gfa_field
+  def validate_gfa_field!(datatype, fieldname=nil)
+    if (datatype == :pos and self < 0)
+      raise RGFA::FieldParser::FormatError,
+        "Invalid content for field #{fieldname}\n"+
+        "Content: #{self.inspect}\n"+
+        "Datatype: #{datatype}"
+    elsif ![:i, :f, :Z].include?(datatype)
+      raise RGFA::FieldParser::FormatError,
+          "Wrong type (#{self.class}) for field #{fieldname}\n"+
+          "Content: #{self.inspect}\n"+
+          "Datatype: #{datatype}"
+    end
+  end
+end
+
 class RGFA::Line::Segment
   # @!macro validate_gfa_field
   def validate_gfa_field!(datatype, fieldname=nil)

--- a/lib/rgfa/field_writer.rb
+++ b/lib/rgfa/field_writer.rb
@@ -65,6 +65,11 @@ class Hash
   def default_gfa_datatype; :J; end
 end
 
+class Integer
+  # @!macro gfa_datatype
+  def default_gfa_datatype; :i; end
+end
+
 class Array
   # @!macro to_gfa_field
   def to_gfa_field(datatype: default_gfa_datatype)


### PR DESCRIPTION
During a Debian package rebuild we noticed that this library fails its test suite with Ruby 3.3 (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1092702)

This is due to some deprecated features that have been removed. This patch fixed the test suite at least. Please review.